### PR TITLE
cmake: install public headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Build directory
+build/

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -151,7 +151,6 @@ install(
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
-# install the public headers
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -160,6 +159,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries( ${PROJECT_NAME} INTERFACE
     spdlog
 )
+
+# install the public headers
+install(DIRECTORY ../include/streaming_protocol DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # install a targets file for the generated export set
 install(


### PR DESCRIPTION
The existing CMake files do not install the library's headers, thus rendering it unusable. This was probably not previously noticed because it still worked when using FetchContent (because in that workflow the headers are taken from the build directory - specifically, the build-interface version of the generator expression is used rather than the install-interface).