### PR TITLE
fix SPDLOG_INSTALL

### DIFF
--- a/lib/external/spdlog/CMakeLists.txt
+++ b/lib/external/spdlog/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
     include(FetchContent)
     get_custom_fetch_content_params(spdlog FC_PARAMS)
 
-    set(SPDLOG_INSTALL ON)
+    set(SPDLOG_INSTALL ON CACHE BOOL "")
 
     FetchContent_Declare(spdlog
                          GIT_REPOSITORY https://github.com/gabime/spdlog.git


### PR DESCRIPTION
The current code does not build correctly with cmake 3.27.7:

    CMake Error: install(EXPORT "streaming_protocol" ...) includes target "streaming_protocol" which requires target "spdlog" that is not in any export set.
    CMake Error: install(EXPORT "streaming_protocol" ...) includes target "streaming_protocol" which requires target "spdlog" that is not in any export set.

The reason is the following line in `lib/external/spdlog/CMakeLists.txt`:

    set(SPDLOG_INSTALL ON)

It generates the following warning:

```
CMake Warning (dev) at build/__external/src/spdlog/CMakeLists.txt:77 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'SPDLOG_INSTALL'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

In order to correctly set this variable, we need to set it as a cache variable, not a normal variable. This PR accomplishes that. Otherwise, spdlog is not installed, and targets which link to spdlog cannot be exported because of the "not in export set" error above (we have to install all fetched dependencies).
