### PR TITLE
Ability to add signal to an existing table

### DIFF
--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -392,14 +392,19 @@ There are some example of signal descriptions in a separate document.
       <contains at least one signal member description>
     },
     "tableId": <string>,
+    ["valueIndex": <uint64>],
     ["relatedSignals": [
         { "type" : <relation type>, "signalId" : <id of the related signal> } 
       ]
-    ]
+    ],
     ["interpretation": {}]
   }
 }
 ~~~~
+
+- `tableId`: Id of the table the signal belongs to
+- `valueIndex`: Optional, and relevant only if domain signal of the table follows an implicit linear rule.
+   Tells the value index of the first value of this signal in the table. If missing, the first value comes at the very beginning (valueIndex = 0).
 
 #### Signal Definition Object
 

--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -403,7 +403,7 @@ There are some example of signal descriptions in a separate document.
 ~~~~
 
 - `tableId`: Id of the table the signal belongs to
-- `valueIndex`: Optional, and relevant only if domain signal of the table follows an implicit linear rule.
+- `valueIndex`: Optional, and relevant only if domain signal of the table follows an implicit rule such as an implicit linear time signal.
    Tells the value index of the first value of this signal in the table. If missing, the first value comes at the very beginning (valueIndex = 0).
 
 #### Signal Definition Object


### PR DESCRIPTION
If the table has a domain signal following an implicit linear rule, and subscribing a data signal later, the signal description of this signal contains the "valueIndex" of the firsr value of this signal to come.