### PR TITLE
Fix Clang14 lib++ compilation

### DIFF
--- a/tool/SignalGenerator/generatedsynchronoussignal.h
+++ b/tool/SignalGenerator/generatedsynchronoussignal.h
@@ -103,7 +103,7 @@ namespace daq::streaming_protocol::siggen{
                         if (m_periodTimeDouble>=m_period-m_samplePeriodDouble) {
                             m_periodTimeDouble = 0.0;
                         }
-#ifdef __linux
+#if defined(__linux) && ! defined(_LIBCPP_VERSION)
 						m_lastProcessTime += m_samplePeriod;
 #else
 						m_lastProcessTime += std::chrono::duration_cast <std::chrono::microseconds> (m_samplePeriod);


### PR DESCRIPTION
Fixes compilation with Clang 14 lib++. Note that I already created a separate branch with the fix for 0.10.12 for usage in the SDK, as the recent commits up until v0.10.13 broke compatibility with the SDK. 