### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,19 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: Ubuntu
             runner: ubuntu-latest
             cmake_generator: "Unix Makefiles"
             cmake_build_type: Debug
-            cmake_defines: -DSTREAMING_PROTOCOL_POST_BUILD_UNITTEST=ON
           - name: Windows
             runner: windows-latest
             cmake_generator: "Visual Studio 17 2022"
             cmake_build_type: Debug
-            cmake_defines: -DSTREAMING_PROTOCOL_POST_BUILD_UNITTEST=ON
 
     steps:
       - name: Checkout repository
@@ -33,7 +31,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G "${{ matrix.cmake_generator }}" ${{ matrix.cmake_defines }} -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} ..
+          cmake -G "${{ matrix.cmake_generator }}" -DSTREAMING_PROTOCOL_POST_BUILD_UNITTEST=ON -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} ..
 
       - name: Build
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ message(STATUS "openDAQ repository prefix: ${OPENDAQ_REPO_PREFIX}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if (MSVC)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++17>)
+endif(MSVC)
+
 if(STREAMING_PROTOCOL_SPECIFICATION)
     add_subdirectory(docs)
 endif(STREAMING_PROTOCOL_SPECIFICATION)
@@ -38,7 +42,6 @@ endif(STREAMING_PROTOCOL_SPECIFICATION)
 if(STREAMING_PROTOCOL_LIB)
     add_subdirectory(lib)
 endif(STREAMING_PROTOCOL_LIB)
-
 
 if(STREAMING_PROTOCOL_TOOLS)
     add_subdirectory(tool)

--- a/lib/Logging.cpp
+++ b/lib/Logging.cpp
@@ -9,6 +9,7 @@ namespace daq::streaming_protocol
         const std::string name = "openDaqStreaming";
         static auto logger =
             std::make_shared<spdlog::logger>(name, std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+        logger->set_level(spdlog::level::trace);
 
         return [](spdlog::source_loc location, spdlog::level::level_enum level, const char* msg) {
             logger->log(location, level, msg);

--- a/lib/external/stream/CMakeLists.txt
+++ b/lib/external/stream/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.24)
 
 set_cmake_folder_context(TARGET_FOLDER_NAME)
 
-set(stream_REQUIREDVERSION "1.0.1")
+set(stream_REQUIREDVERSION "1.0.2")
 if (NOT STREAMING_PROTOCOL_ALWAYS_FETCH_DEPS)
     message(STATUS "Looking for preinstalled stream")
     find_package(stream ${stream_REQUIREDVERSION} GLOBAL QUIET)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -113,24 +113,29 @@ add_executable( SubscribedSignal.test
     SubscribedSignalTest.cpp
 )
 
-add_executable( Signal.test
-    SignalTest.cpp
-)
-
 if (NOT WIN32)
     # FileStream is used here which is not supported under windows
+
+    add_executable( Signal.test
+        SignalTest.cpp
+    )
+
     add_executable( ProducerSession.test
         ProducerSessionTest.cpp
     )
+
+    add_executable( ProtocolHandlerTest.test
+        ProtocolHandlerTest.cpp
+    )
+
+    add_executable( StreamWriter.test
+        StreamWriterTest.cpp
+    )
+
+    add_executable( CompleteWebsocketSession.test
+        CompleteWebsocketSessionTest.cpp
+    )
 endif()
-
-add_executable( ProtocolHandlerTest.test
-    ProtocolHandlerTest.cpp
-)
-
-add_executable( StreamWriter.test
-    StreamWriterTest.cpp
-)
 
 add_executable( Control.Test
     ControlTest.cpp
@@ -138,9 +143,6 @@ add_executable( Control.Test
 
 add_executable( Server.test
     ServerTest.cpp
-)
-add_executable( CompleteWebsocketSession.test
-	CompleteWebsocketSessionTest.cpp
 )
 
 get_property(targets DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" PROPERTY BUILDSYSTEM_TARGETS)

--- a/tool/SignalGenerator/CMakeLists.txt
+++ b/tool/SignalGenerator/CMakeLists.txt
@@ -32,15 +32,16 @@ endif()
 
 target_link_libraries(siggenCommon PUBLIC daq::streaming_protocol daq::stream nlohmann_json::nlohmann_json spdlog::spdlog fmt::fmt)
 
+if (NOT WIN32)
+    # FileStream is not supported on win32
+    set(SIGGEN2FILE_SOURCES
+      siggen2file.cpp
+    )
 
-
-set(SIGGEN2FILE_SOURCES
-  siggen2file.cpp
-)
-
-add_executable(siggen2file
-  ${SIGGEN2FILE_SOURCES}
-)
+    add_executable(siggen2file
+      ${SIGGEN2FILE_SOURCES}
+    )
+endif()
 
 set(SIGGEN2SOCKET_SOURCES
   siggen2socket.cpp
@@ -62,8 +63,18 @@ add_executable(siggen2websocket
   ${SIGGEN2WEBSOCKET_SOURCES}
 )
 
+if (NOT WIN32)
+    set(SIGGEN_TARGETS siggen2file
+                       siggen2socket
+                       siggen2websocket
+    )
+else()
+    set(SIGGEN_TARGETS siggen2socket
+                       siggen2websocket
+    )
+endif()
 
-foreach(tgt siggen2file siggen2socket siggen2websocket)
+foreach(tgt ${SIGGEN_TARGETS})
 #    target_include_directories(${tgt} PRIVATE "../../include")
     target_compile_features(${tgt} PRIVATE cxx_std_17)
     target_link_libraries(${tgt} PRIVATE


### PR DESCRIPTION
* switch to lib stream version [1.0.2](https://github.com/openDAQ/libstream/pull/3) - fix Boost fetching
* increase workflow timeout
* fix windows build - add flag MSVC flag for c++17, disable unsupported tests
* log any messages with default logger