### PR TITLE
cmake: need find_dependency(spdlog) in config template

### DIFF
--- a/lib/Config.cmake.in
+++ b/lib/Config.cmake.in
@@ -5,4 +5,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 include(CMakeFindDependencyMacro)
 
 find_dependency(nlohmann_json REQUIRED)
+find_dependency(spdlog REQUIRED)
 find_dependency(stream REQUIRED)


### PR DESCRIPTION
Otherwise, users who need the streaming protocol (and who are loading it from a preinstalled library using CMake find_package Config Mode) but who do not themselves need spdlog will fail because they did not load spdlog. This is the purpose of find_dependency() which must be included in the CMake package config file for all transitive dependencies.