### PR TITLE
Remove code duplication for unit handling. Add access to unit quantity.

### DIFF
--- a/include/streaming_protocol/AsynchronousSignal.hpp
+++ b/include/streaming_protocol/AsynchronousSignal.hpp
@@ -97,11 +97,7 @@ private:
         memberInformation[META_NAME] = m_valueName;
         memberInformation[META_DATATYPE] = dataType;
         memberInformation[META_RULE] = META_RULETYPE_EXPLICIT;
-        if (m_unitId != Unit::UNIT_ID_NONE) {
-            memberInformation[META_UNIT][META_UNIT_ID] = m_unitId;
-            memberInformation[META_UNIT][META_DISPLAY_NAME] = m_unitDisplayName;
-        }
-
+        m_unit.compose(memberInformation);
         m_range.compose(memberInformation);
         m_postScaling.compose(memberInformation);
         return memberInformation;

--- a/include/streaming_protocol/BaseDomainSignal.hpp
+++ b/include/streaming_protocol/BaseDomainSignal.hpp
@@ -19,6 +19,7 @@
 #include "streaming_protocol/BaseSignal.hpp"
 #include "streaming_protocol/Defines.h"
 #include "streaming_protocol/iWriter.hpp"
+#include "streaming_protocol/Unit.hpp"
 
 namespace daq::streaming_protocol{
     /// \addtogroup producer
@@ -61,5 +62,6 @@ namespace daq::streaming_protocol{
 
         uint64_t m_timeTicksPerSecond;
         std::string m_epoch = UNIX_EPOCH;
+        Unit m_unitSecond;
     };
 }

--- a/include/streaming_protocol/BaseValueSignal.hpp
+++ b/include/streaming_protocol/BaseValueSignal.hpp
@@ -25,6 +25,7 @@
 #include "streaming_protocol/iWriter.hpp"
 #include "streaming_protocol/Types.h"
 #include "streaming_protocol/Logging.hpp"
+#include "streaming_protocol/Unit.hpp"
 
 /// \warning Since only C++ libraries under linux allow resolution down to nanoseconds, resolution is limited to microseconds
 //#define TIME_GRANULARITY_NS
@@ -53,11 +54,13 @@ namespace daq::streaming_protocol{
         /// \return Name of the root data member
         std::string getMemberName() const;
 
+        Unit getUnit() const;
         int32_t getUnitId() const;
         std::string getUnitDisplayName() const;
 
         //// \param unitId Unit::UNIT_ID_NONE for no unit
         void setUnit(int32_t unitId, const std::string& displayName);
+        void setUnit(const Unit& value);
 
         void setPostScaling(const PostScaling postScaling)
         {
@@ -82,8 +85,7 @@ namespace daq::streaming_protocol{
     protected:
 
         std::string m_valueName;
-        int32_t m_unitId;
-        std::string m_unitDisplayName;
+        Unit m_unit;
         PostScaling m_postScaling;
         Range m_range;
 

--- a/include/streaming_protocol/ExplicitTimeSignal.hpp
+++ b/include/streaming_protocol/ExplicitTimeSignal.hpp
@@ -21,7 +21,7 @@
 
 namespace daq::streaming_protocol{
     /// \addtogroup producer
-    /// Abstrace base class for producing signal data
+    /// Abstract base class for producing domain signal
     class ExplicitTimeSignal : public BaseDomainSignal {
     public:
         ExplicitTimeSignal(const std::string& signalId, const std::string& tableId, uint64_t timeTicksPerSecond, iWriter &writer, LogCallback logCb);

--- a/include/streaming_protocol/SubscribedSignal.hpp
+++ b/include/streaming_protocol/SubscribedSignal.hpp
@@ -136,7 +136,7 @@ public:
     /// \return Unit id of the scalar signal member
     int32_t unitId() const
     {
-        return m_unit.unitId;
+        return m_unit.id;
     }
 
     /// Set the current timestamp for the signal. It will be used for the next appearing value.

--- a/include/streaming_protocol/Unit.hpp
+++ b/include/streaming_protocol/Unit.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <cstdint>
 
+#include <nlohmann/json.hpp>
+
 namespace daq::streaming_protocol {
 
 
@@ -31,9 +33,23 @@ struct Unit {
 
     Unit();
 
+    bool operator==(const Unit &other) const
+    {
+        return (
+                (id==other.id) &&
+                (displayName==other.displayName) &&
+                (quantity==other.quantity)
+               );
+    }
+
+    void clear();
+
+    void compose(nlohmann::json &composition) const;
+    void parse(const nlohmann::json& composition);
+
     /// -1 stands for no unit
     /// 0 stands for user defined unit without unit id
-    int32_t unitId;
+    int32_t id;
     std::string displayName;
     std::string quantity;
 };

--- a/lib/BaseConstantSignal.cpp
+++ b/lib/BaseConstantSignal.cpp
@@ -26,10 +26,9 @@ nlohmann::json BaseConstantSignal::createMember(const std::string &dataType) con
     memberInformation[META_NAME] = m_valueName;
     memberInformation[META_DATATYPE] = dataType;
     memberInformation[META_RULE] = META_RULETYPE_CONSTANT;
-    if (m_unitId != Unit::UNIT_ID_NONE) {
-        memberInformation[META_UNIT][META_UNIT_ID] = m_unitId;
-        memberInformation[META_UNIT][META_DISPLAY_NAME] = m_unitDisplayName;
-    }
+    m_unit.compose(memberInformation);
+    m_range.compose(memberInformation);
+    m_postScaling.compose(memberInformation);
     return memberInformation;
 }
 

--- a/lib/BaseDomainSignal.cpp
+++ b/lib/BaseDomainSignal.cpp
@@ -13,6 +13,9 @@ BaseDomainSignal::BaseDomainSignal(const std::string& signalId, const std::strin
     : BaseSignal(signalId, tableId, writer, logCb)
     , m_timeTicksPerSecond(timeTicksPerSecond)
 {
+    m_unitSecond.id = Unit::UNIT_ID_SECONDS;
+    m_unitSecond.displayName = "s";
+    m_unitSecond.quantity = META_TIME;
 }
 
 void BaseDomainSignal::setEpoch(const std::string& epoch)

--- a/lib/BaseSynchronousSignal.cpp
+++ b/lib/BaseSynchronousSignal.cpp
@@ -26,10 +26,7 @@ nlohmann::json daq::streaming_protocol::BaseSynchronousSignal::createMember(cons
     memberInformation[META_NAME] = m_valueName;
     memberInformation[META_DATATYPE] = dataType;
     memberInformation[META_RULE] = META_RULETYPE_EXPLICIT;
-    if (m_unitId != Unit::UNIT_ID_NONE) {
-        memberInformation[META_UNIT][META_UNIT_ID] = m_unitId;
-        memberInformation[META_UNIT][META_DISPLAY_NAME] = m_unitDisplayName;
-    }
+    m_unit.compose(memberInformation);
     m_range.compose(memberInformation);
     m_postScaling.compose(memberInformation);
     return memberInformation;

--- a/lib/BaseValueSignal.cpp
+++ b/lib/BaseValueSignal.cpp
@@ -4,24 +4,33 @@
 daq::streaming_protocol::BaseValueSignal::BaseValueSignal(const std::string &signalId, const std::string &tableId, iWriter &writer, LogCallback logCb)
     : BaseSignal(signalId, tableId, writer, logCb)
     , m_valueName("value")
-    , m_unitId(Unit::UNIT_ID_NONE)
 {
+}
+
+daq::streaming_protocol::Unit daq::streaming_protocol::BaseValueSignal::getUnit() const
+{
+    return m_unit;
 }
 
 int32_t daq::streaming_protocol::BaseValueSignal::getUnitId() const
 {
-    return m_unitId;
+    return m_unit.id;
 }
 
 std::string daq::streaming_protocol::BaseValueSignal::getUnitDisplayName() const
 {
-    return m_unitDisplayName;
+    return m_unit.displayName;
 }
 
 void daq::streaming_protocol::BaseValueSignal::setUnit(int32_t unitId, const std::string& displayName)
 {
-    m_unitId = unitId;
-    m_unitDisplayName = displayName;
+    m_unit.id = unitId;
+    m_unit.displayName = displayName;
+}
+
+void daq::streaming_protocol::BaseValueSignal::setUnit(const Unit &value)
+{
+    m_unit = value;
 }
 
 void daq::streaming_protocol::BaseValueSignal::setMemberName(const std::string &name)
@@ -33,3 +42,4 @@ std::string daq::streaming_protocol::BaseValueSignal::getMemberName() const
 {
     return m_valueName;
 }
+

--- a/lib/ExplicitTimeSignal.cpp
+++ b/lib/ExplicitTimeSignal.cpp
@@ -6,9 +6,6 @@
 #include "streaming_protocol/Unit.hpp"
 
 
-#include <iostream>
-
-
 namespace daq::streaming_protocol {
 
 ExplicitTimeSignal::ExplicitTimeSignal(const std::string& signalId, const std::string& tableId, uint64_t timeTicksPerSecond, iWriter &writer, LogCallback logCb)
@@ -40,9 +37,7 @@ nlohmann::json ExplicitTimeSignal::getMemberInformation() const
     memberInformation[META_NAME] = META_TIME;
     memberInformation[META_RULE] = META_RULETYPE_EXPLICIT;
     memberInformation[META_DATATYPE] = DATA_TYPE_UINT64;
-    memberInformation[META_UNIT][META_UNIT_ID] = Unit::UNIT_ID_SECONDS;
-    memberInformation[META_UNIT][META_DISPLAY_NAME] = "s";
-    memberInformation[META_UNIT][META_QUANTITY] = META_TIME;
+    m_unitSecond.compose(memberInformation);
     memberInformation[META_ABSOLUTE_REFERENCE] = m_epoch;
     memberInformation[META_RESOLUTION][META_NUMERATOR] = 1;
     memberInformation[META_RESOLUTION][META_DENOMINATOR] = m_timeTicksPerSecond;

--- a/lib/LinearTimeSignal.cpp
+++ b/lib/LinearTimeSignal.cpp
@@ -5,8 +5,6 @@
 #include "streaming_protocol/LinearTimeSignal.hpp"
 #include "streaming_protocol/Unit.hpp"
 
-#include <iostream>
-
 
 namespace daq::streaming_protocol {
 
@@ -57,9 +55,7 @@ nlohmann::json LinearTimeSignal::getMemberInformation() const
     memberInformation[META_RULE] = META_RULETYPE_LINEAR;
     memberInformation[META_RULETYPE_LINEAR][META_DELTA] = m_outputRateInTicks;
     memberInformation[META_DATATYPE] = DATA_TYPE_UINT64;
-    memberInformation[META_UNIT][META_UNIT_ID] = Unit::UNIT_ID_SECONDS;
-    memberInformation[META_UNIT][META_DISPLAY_NAME] = "s";
-    memberInformation[META_UNIT][META_QUANTITY] = META_TIME;
+    m_unitSecond.compose(memberInformation);
     memberInformation[META_ABSOLUTE_REFERENCE] = m_epoch;
     memberInformation[META_RESOLUTION][META_NUMERATOR] = 1;
     memberInformation[META_RESOLUTION][META_DENOMINATOR] = m_timeTicksPerSecond;

--- a/lib/SubscribedSignal.cpp
+++ b/lib/SubscribedSignal.cpp
@@ -369,9 +369,8 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                     STREAMING_PROTOCOL_LOG_I("\tabsolute reference: {}", m_timeBaseEpochAsString);
                 }
 
-                const nlohmann::json definitionRef = *definitionIter;
-                m_range.parse(definitionRef);
-                m_postScaling.parse(definitionRef);
+                m_range.parse(definitionNode);
+                m_postScaling.parse(definitionNode);
 
                 if (m_isTimeSignal) {
                     // separate check because time chapter may only be send initialy, later changes won't have this again!

--- a/lib/SubscribedSignal.cpp
+++ b/lib/SubscribedSignal.cpp
@@ -337,25 +337,9 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                     }
                 }
 
-                auto unitIter = definitionNode.find(META_UNIT);
-                if (unitIter != definitionNode.end()) {
-                    nlohmann::json unitNode = *unitIter;
-                    auto displayNameIter = unitNode.find(META_DISPLAY_NAME);
-                    if (displayNameIter != unitNode.end()) {
-                        m_unit.displayName = *displayNameIter;
-                    }
-                    auto unitIdIter = unitNode.find(META_UNIT_ID);
-                    if (unitIdIter != unitNode.end()) {
-                        m_unit.unitId = *unitIdIter;
-                    }
-
-                    auto unitQuantityIter = unitNode.find(META_QUANTITY);
-                    if (unitQuantityIter != unitNode.end()) {
-                        m_unit.quantity = *unitQuantityIter;
-                        if (m_unit.quantity==META_TIME) {
-                            m_isTimeSignal = true;
-                        }
-                    }
+                m_unit.parse(definitionNode);
+                if (m_unit.quantity==META_TIME) {
+                    m_isTimeSignal = true;
                 }
 
                 auto resolutionIter = definitionNode.find(META_RESOLUTION);
@@ -368,7 +352,7 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                         return -1;
                     }
                     // numerator/denominator gives time between ticks, or period, in the uint of the signal.
-                    if (m_unit.unitId == Unit::UNIT_ID_SECONDS) {
+                    if (m_unit.id == Unit::UNIT_ID_SECONDS) {
                         // Unit for time signals is seconds. We want the frequency here!
                         m_timeBaseFrequency = denominator / numerator;
                         STREAMING_PROTOCOL_LOG_I("\ttime resolution: {} Hz", resolutionNode.dump());

--- a/lib/Unit.cpp
+++ b/lib/Unit.cpp
@@ -1,4 +1,5 @@
-﻿#include "streaming_protocol/Unit.hpp"
+﻿#include "streaming_protocol/Defines.h"
+#include "streaming_protocol/Unit.hpp"
 
 namespace daq::streaming_protocol {
     const int32_t Unit::UNIT_ID_USER = 0;
@@ -8,6 +9,45 @@ namespace daq::streaming_protocol {
     const int32_t Unit::UNIT_ID_MILLI_SECONDS = 4403766;
 
     Unit::Unit()
-        : unitId(UNIT_ID_NONE)
+        : id(UNIT_ID_NONE)
     {}
+
+    void Unit::clear()
+    {
+        id = Unit::UNIT_ID_NONE;
+        displayName.clear();
+        quantity.clear();
+    }
+
+    void Unit::compose(nlohmann::json &composition) const
+    {
+        if (id != Unit::UNIT_ID_NONE) {
+            composition[META_UNIT][META_UNIT_ID] = id;
+            composition[META_UNIT][META_DISPLAY_NAME] = displayName;
+            if (!quantity.empty()) {
+                // quantity is optional
+                composition[META_UNIT][META_QUANTITY] = quantity;
+            }
+        }
+    }
+
+    void Unit::parse(const nlohmann::json& composition)
+    {
+        auto unitNode = composition.find(META_UNIT);
+        if (unitNode!=composition.end()) {
+            auto uintIdIter = unitNode->find(META_UNIT_ID);
+            if (uintIdIter!=unitNode->end()) {
+                id = *uintIdIter;
+            }
+            auto displayNameIter = unitNode->find(META_DISPLAY_NAME);
+            if (displayNameIter!=unitNode->end()) {
+                displayName = *displayNameIter;
+            }
+            auto quantityIter = unitNode->find(META_QUANTITY);
+            if (quantityIter!=unitNode->end()) {
+                quantity = *quantityIter;
+            }
+        }
+
+    }
 };


### PR DESCRIPTION
There was lots of code duplication concerning unit handling. Not all occurences were tested. 
On consumer side we missed also an accessor for the unit quantity
Range and postscaling also for constant signal