### PR TITLE
Related signals

### DIFF
--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -158,8 +158,11 @@ This allows the client to know when all signals are described and data is to be 
 ### Value Index
 An uint64 sent with each value of an implicit signal. It is used to align the value of the implicit signal with the table steps.
 
+### Related Signals
+A signal may have related signals that carry additional information. Exemples are domain signal and status signal.
+Each relation is described by the id of the related signal and the type of the related signal (i.e. "domain", "status").
 
-
+Only signal that are already subscribed may be used as related signal!
 
 ### Meta Information
 

--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -159,7 +159,7 @@ This allows the client to know when all signals are described and data is to be 
 An uint64 sent with each value of an implicit signal. It is used to align the value of the implicit signal with the table steps.
 
 ### Related Signals
-A signal may have related signals that carry additional information. Exemples are domain signal and status signal.
+A signal may have related signals that carry additional information. Examples are domain signal and status signal.
 Each relation is described by the id of the related signal and the type of the related signal (i.e. "domain", "status").
 
 Only signal that are already subscribed may be used as related signal!

--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -162,7 +162,7 @@ An uint64 sent with each value of an implicit signal. It is used to align the va
 A signal may have related signals that carry additional information. Examples are domain signal and status signal.
 Each relation is described by the id of the related signal and the type of the related signal (i.e. "domain", "status").
 
-Only signal that are already subscribed may be used as related signal!
+Only signals that are already subscribed may be used as related signals!
 
 ### Meta Information
 

--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -394,15 +394,13 @@ There are some example of signal descriptions in a separate document.
     },
     "tableId": <string>,
     ["valueIndex": <uint64>],
-    {
-      "relatedSignals": 
-      [
-        { 
-          "type" : <relation type>, 
-          "signalId" : <id of the related signal>
-        } 
-      ]
-    },
+    "relatedSignals": 
+    [
+      { 
+        "type" : <relation type>, 
+        "signalId" : <id of the related signal>
+      } 
+    ],
     ["interpretation": {}]
   }
 }

--- a/include/streaming_protocol/AsynchronousSignal.hpp
+++ b/include/streaming_protocol/AsynchronousSignal.hpp
@@ -109,10 +109,12 @@ private:
         nlohmann::json dataSignal;
         dataSignal[METHOD] = META_METHOD_SIGNAL;
         dataSignal[PARAMS][META_TABLEID] = m_tableId;
-        dataSignal[PARAMS][META_DEFINITION] = getMemberInformation();
         if (!m_interpretationObject.is_null()) {
             dataSignal[PARAMS][META_INTERPRETATION] = m_interpretationObject;
         }
+
+        dataSignal[PARAMS][META_DEFINITION] = getMemberInformation();
+        composeRelatedSignals(dataSignal[PARAMS]);
         m_writer.writeMetaInformation(m_signalNumber, dataSignal);
     }
 

--- a/include/streaming_protocol/BaseValueSignal.hpp
+++ b/include/streaming_protocol/BaseValueSignal.hpp
@@ -74,7 +74,7 @@ namespace daq::streaming_protocol{
 
         void setRange(const Range& range)
         {
-            m_range =range;
+            m_range = range;
         }
 
         void clearRange()
@@ -82,12 +82,27 @@ namespace daq::streaming_protocol{
             m_range.clear();
         }
 
+        void setRelatedSignals(const RelatedSignals& relatedSignals)
+        {
+            m_relatedSignals = relatedSignals;
+        }
+
     protected:
+
+        void composeRelatedSignals(nlohmann::json& composition) const
+        {
+            for(auto iter : m_relatedSignals) {
+                 nlohmann::json relatedSignal;
+                 relatedSignal[META_TYPE] = iter.first;
+                 relatedSignal[META_SIGNALID] = iter.second;
+                 composition[META_RELATEDSIGNALS].push_back(relatedSignal);
+             }
+        }
 
         std::string m_valueName;
         Unit m_unit;
         PostScaling m_postScaling;
         Range m_range;
-
+        RelatedSignals m_relatedSignals;
     };
 }

--- a/include/streaming_protocol/Defines.h
+++ b/include/streaming_protocol/Defines.h
@@ -59,6 +59,8 @@ static const char META_TABLEID[] = "tableId";
 static const char META_VALUEINDEX[] = "valueIndex";
 static const char META_RELATEDSIGNALS[] = "relatedSignals";
 
+static const char META_TYPE[] = "type";
+
 /// Is send to acknowldege the sunscription of a signal. It carries the signal id togehter with the signal number.
 static const char META_METHOD_SUBSCRIBE[] = "subscribe";
 /// Is send to acknowldege that sunscription a signal got unsubscribed.

--- a/include/streaming_protocol/SubscribedSignal.hpp
+++ b/include/streaming_protocol/SubscribedSignal.hpp
@@ -199,6 +199,9 @@ public:
 
 private:
 
+    /// Signal type is the key signal id is the value.
+    /// Currently types "time" and "status" are specified
+    using RelatedSignals = std::map < std::string, std::string>;
     template < typename DataType >
     inline void convert(const uint8_t *pData, size_t count, double* doubleValueBuffer) const
     {
@@ -250,5 +253,6 @@ private:
 
     nlohmann::json m_interpretationObject;
     LogCallback logCallback;
+    RelatedSignals m_relatedSignals;
 };
 }

--- a/include/streaming_protocol/SubscribedSignal.hpp
+++ b/include/streaming_protocol/SubscribedSignal.hpp
@@ -197,11 +197,13 @@ public:
         return m_range;
     }
 
+    RelatedSignals relatedSignals() const
+    {
+        return m_relatedSignals;
+    }
+
 private:
 
-    /// Signal type is the key signal id is the value.
-    /// Currently types "time" and "status" are specified
-    using RelatedSignals = std::map < std::string, std::string>;
     template < typename DataType >
     inline void convert(const uint8_t *pData, size_t count, double* doubleValueBuffer) const
     {

--- a/include/streaming_protocol/Types.h
+++ b/include/streaming_protocol/Types.h
@@ -120,4 +120,9 @@ struct Range
     double high;
 };
 
+/// Signal type is the key signal id is the value.
+/// Currently types "time" and "status" are specified
+using RelatedSignals = std::map < std::string, std::string>;
+
+
 }

--- a/lib/BaseConstantSignal.cpp
+++ b/lib/BaseConstantSignal.cpp
@@ -13,10 +13,12 @@ void BaseConstantSignal::writeSignalMetaInformation() const
     nlohmann::json dataSignal;
     dataSignal[METHOD] = META_METHOD_SIGNAL;
     dataSignal[PARAMS][META_TABLEID] = m_tableId;
-    dataSignal[PARAMS][META_DEFINITION] = getMemberInformation();
     if (!m_interpretationObject.is_null()) {
         dataSignal[PARAMS][META_INTERPRETATION] = m_interpretationObject;
     }
+
+    dataSignal[PARAMS][META_DEFINITION] = getMemberInformation();
+    composeRelatedSignals(dataSignal[PARAMS]);
     m_writer.writeMetaInformation(m_signalNumber, dataSignal);
 }
 

--- a/lib/BaseSynchronousSignal.cpp
+++ b/lib/BaseSynchronousSignal.cpp
@@ -12,11 +12,13 @@ void daq::streaming_protocol::BaseSynchronousSignal::writeSignalMetaInformation(
     nlohmann::json dataSignal;
     dataSignal[METHOD] = META_METHOD_SIGNAL;
     dataSignal[PARAMS][META_TABLEID] = m_tableId;
-    dataSignal[PARAMS][META_DEFINITION] = getMemberInformation();
-    dataSignal[PARAMS][META_VALUEINDEX] = m_valueIndex;
     if (!m_interpretationObject.is_null()) {
         dataSignal[PARAMS][META_INTERPRETATION] = m_interpretationObject;
     }
+
+    dataSignal[PARAMS][META_DEFINITION] = getMemberInformation();
+    dataSignal[PARAMS][META_VALUEINDEX] = m_valueIndex;
+    composeRelatedSignals(dataSignal[PARAMS]);
     m_writer.writeMetaInformation(m_signalNumber, dataSignal);
 }
 

--- a/lib/SubscribedSignal.cpp
+++ b/lib/SubscribedSignal.cpp
@@ -385,8 +385,8 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                     }
                 }
 
-                auto relatedSignalsIter = definitionNode.find(META_RELATEDSIGNALS);
-                if (relatedSignalsIter != definitionNode.end()) {
+                auto relatedSignalsIter = params.find(META_RELATEDSIGNALS);
+                if (relatedSignalsIter != params.end()) {
                     m_relatedSignals.clear();
                     STREAMING_PROTOCOL_LOG_I("\tRelated signals", m_signalId);
                     const nlohmann::json& relatedSignals = *relatedSignalsIter;

--- a/lib/SubscribedSignal.cpp
+++ b/lib/SubscribedSignal.cpp
@@ -385,15 +385,16 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                     }
                 }
 
-                definitionIter = params.find(META_RELATEDSIGNALS);
-                if (definitionIter != params.end()) {
-                    STREAMING_PROTOCOL_LOG_I("{}:", m_signalId);
+                auto relatedSignalsIter = definitionNode.find(META_RELATEDSIGNALS);
+                if (relatedSignalsIter != definitionNode.end()) {
+                    m_relatedSignals.clear();
                     STREAMING_PROTOCOL_LOG_I("\tRelated signals", m_signalId);
-                    nlohmann::json relatedSignals = *definitionIter;
+                    const nlohmann::json& relatedSignals = *relatedSignalsIter;
                     if (relatedSignals.is_array()) {
                         for (const auto& arrayItem: relatedSignals) {
-                            std::string type = arrayItem["type"];
-                            std::string signalId = arrayItem["signalId"];
+                            std::string type = arrayItem[META_TYPE];
+                            std::string signalId = arrayItem[META_SIGNALID];
+                            m_relatedSignals[type] = signalId;
                             STREAMING_PROTOCOL_LOG_I("\t\tsignal id: {}, type: ", signalId, type);
                         }
                     }

--- a/test/SubscribedSignalTest.cpp
+++ b/test/SubscribedSignalTest.cpp
@@ -173,7 +173,7 @@ namespace daq::streaming_protocol {
         {
             nlohmann::json metaDataSignal;
             metaDataSignal[META_TABLEID] = dataSignal.tableId();
-            metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_TYPE] = "time";
+            metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_TYPE] = META_TIME;
             metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_SIGNALID] = timeSignal->signalId();
             result = timeSignal->processSignalMetaInformation(META_METHOD_SIGNAL, metaDataSignal);
             ASSERT_EQ(result, 0);

--- a/test/SubscribedSignalTest.cpp
+++ b/test/SubscribedSignalTest.cpp
@@ -173,8 +173,8 @@ namespace daq::streaming_protocol {
         {
             nlohmann::json metaDataSignal;
             metaDataSignal[META_TABLEID] = dataSignal.tableId();
-            metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_TYPE] = META_TIME;
-            metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_SIGNALID] = timeSignal->signalId();
+            metaDataSignal[META_RELATEDSIGNALS][0][META_TYPE] = META_TIME;
+            metaDataSignal[META_RELATEDSIGNALS][0][META_SIGNALID] = timeSignal->signalId();
             result = timeSignal->processSignalMetaInformation(META_METHOD_SIGNAL, metaDataSignal);
             ASSERT_EQ(result, 0);
         }

--- a/test/SubscribedSignalTest.cpp
+++ b/test/SubscribedSignalTest.cpp
@@ -139,28 +139,45 @@ namespace daq::streaming_protocol {
     void static prepareSignals(SubscribedSignal& dataSignal, std::shared_ptr < SubscribedSignal> timeSignal, uint64_t startTime)
     {
         int result;
-        nlohmann::json metaTimeSignal;
-        nlohmann::json metaTimeSubscribe;
-        metaTimeSubscribe[META_SIGNALID] = "da time!";
-        result = timeSignal->processSignalMetaInformation(META_METHOD_SUBSCRIBE, metaTimeSubscribe);
-        ASSERT_EQ(result, 0);
-        uint64_t deltaTime = 1;
 
-        metaTimeSignal[META_TABLEID] = dataSignal.tableId();
-        metaTimeSignal[META_DEFINITION][META_RULE] = META_RULETYPE_LINEAR;
-        metaTimeSignal[META_DEFINITION][META_RULETYPE_LINEAR][META_DELTA] = deltaTime;
-        metaTimeSignal[META_DEFINITION][META_DATATYPE] = DATA_TYPE_UINT64;
-        result = timeSignal->processSignalMetaInformation(META_METHOD_SIGNAL, metaTimeSignal);
-        ASSERT_EQ(result, 0);
+        {
+            nlohmann::json metaTimeSubscribe;
+            std::string timeSignalId = "da time!";
+            metaTimeSubscribe[META_SIGNALID] = timeSignalId;
+            result = timeSignal->processSignalMetaInformation(META_METHOD_SUBSCRIBE, metaTimeSubscribe);
+            ASSERT_EQ(result, 0);
+        }
+
+        {
+            uint64_t deltaTime = 1;
+            nlohmann::json metaTimeSignal;
+            metaTimeSignal[META_TABLEID] = dataSignal.tableId();
+            metaTimeSignal[META_DEFINITION][META_RULE] = META_RULETYPE_LINEAR;
+            metaTimeSignal[META_DEFINITION][META_RULETYPE_LINEAR][META_DELTA] = deltaTime;
+            metaTimeSignal[META_DEFINITION][META_DATATYPE] = DATA_TYPE_UINT64;
+            result = timeSignal->processSignalMetaInformation(META_METHOD_SIGNAL, metaTimeSignal);
+            ASSERT_EQ(result, 0);
+        }
 
         /// timestamp of the next value to be delivered
         timeSignal->setTime(startTime);
 
-        nlohmann::json metaDataSubscribe;
-        std::string signalId = "da data!";
-        metaDataSubscribe[META_SIGNALID] = signalId;
-        result = dataSignal.processSignalMetaInformation(META_METHOD_SUBSCRIBE, metaDataSubscribe);
-        ASSERT_EQ(result, 0);
+        {
+            nlohmann::json metaDataSubscribe;
+            std::string dataSignalId = "da data!";
+            metaDataSubscribe[META_SIGNALID] = dataSignalId;
+            result = dataSignal.processSignalMetaInformation(META_METHOD_SUBSCRIBE, metaDataSubscribe);
+            ASSERT_EQ(result, 0);
+        }
+
+        {
+            nlohmann::json metaDataSignal;
+            metaDataSignal[META_TABLEID] = dataSignal.tableId();
+            metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_TYPE] = "time";
+            metaDataSignal[META_DEFINITION][META_RELATEDSIGNALS][0][META_SIGNALID] = timeSignal->signalId();
+            result = timeSignal->processSignalMetaInformation(META_METHOD_SIGNAL, metaDataSignal);
+            ASSERT_EQ(result, 0);
+        }
     }
 
     TEST(SubscribedSignalTest, dataCb_uint16_test)

--- a/tool/SignalGenerator/generatedasynchronoussignal.h
+++ b/tool/SignalGenerator/generatedasynchronoussignal.h
@@ -51,6 +51,7 @@ namespace daq::streaming_protocol::siggen{
         /// \param startTime The abolute start time can be used to enable a signal later than others. Usefull for implementing a phase shift between signals
         GeneratedAsynchronousSignal(const std::string& signalId,
                                     const std::string& tableId,
+                                    const std::string& timeSignalId,
                                     FunctionParameters <DataType> functionParameters,
                                     std::chrono::nanoseconds samplePeriod,
                                     const std::chrono::time_point<std::chrono::system_clock> &currentTime,
@@ -74,6 +75,9 @@ namespace daq::streaming_protocol::siggen{
 
             m_signal->setRange(functionParameters.range);
             m_signal->setPostScaling(functionParameters.postScaling);
+            RelatedSignals relatedSignals;
+            relatedSignals[META_TIME] = timeSignalId;
+            m_signal->setRelatedSignals(relatedSignals);
         }
         /// not to be copied!
         GeneratedAsynchronousSignal(const GeneratedAsynchronousSignal&) = delete;

--- a/tool/SignalGenerator/generatedsynchronoussignal.h
+++ b/tool/SignalGenerator/generatedsynchronoussignal.h
@@ -53,6 +53,7 @@ namespace daq::streaming_protocol::siggen{
         /// \param samplePeriod Samples are taken with this rate. Not to be confused with the signal frequency!
         GeneratedSynchronousSignal(const std::string& signalId,
                                    const std::string& tableId,
+                                   const std::string& timeSignalId,
                                    FunctionParameters <DataType> functionParameters,
                                    std::chrono::nanoseconds samplePeriod,
                                    const std::chrono::time_point<std::chrono::system_clock> &currentTime,
@@ -71,6 +72,9 @@ namespace daq::streaming_protocol::siggen{
         {
             m_signal->setRange(functionParameters.range);
             m_signal->setPostScaling(functionParameters.postScaling);
+            RelatedSignals relatedSignals;
+            relatedSignals[META_TIME] = timeSignalId;
+            m_signal->setRelatedSignals(relatedSignals);
         }
         /// not to be copied!
         GeneratedSynchronousSignal(const GeneratedSynchronousSignal&) = delete;

--- a/tool/SignalGenerator/signaldefinition.cpp
+++ b/tool/SignalGenerator/signaldefinition.cpp
@@ -52,7 +52,7 @@ void daq::streaming_protocol::siggen::addSignals(daq::streaming_protocol::siggen
     dblSignalParameters.dutyCycle = 0.5;
     dblSignalParameters.functionType = daq::streaming_protocol::siggen::FUNCTION_TYPE_RECTANGLE;
     signalGenerator.addExplicitTimeSignal("async_time", "table_50ms", samplePeriod);
-    signalGenerator.addAsynchronousSignal<double>("async_square", "table_50ms", dblSignalParameters, samplePeriod);
+    signalGenerator.addAsynchronousSignal<double>("async_square", "table_50ms", "async_time", dblSignalParameters, samplePeriod);
 
     samplePeriod = std::chrono::milliseconds(10);
     dblSignalParameters.amplitude = 10;
@@ -60,7 +60,7 @@ void daq::streaming_protocol::siggen::addSignals(daq::streaming_protocol::siggen
     dblSignalParameters.frequency = 0.1;
     dblSignalParameters.functionType = daq::streaming_protocol::siggen::FUNCTION_TYPE_SINE;
     signalGenerator.addLinearTimeSignal("sine_time", "table_10ms", samplePeriod);
-    signalGenerator.addSynchronousSignal<double>("sine", "table_10ms", dblSignalParameters, samplePeriod, 0);
+    signalGenerator.addSynchronousSignal<double>("sine", "table_10ms", "sine_time", dblSignalParameters, samplePeriod, 0);
 
     samplePeriod = std::chrono::milliseconds(100);
     dblSignalParameters.amplitude = 2.5;
@@ -68,16 +68,16 @@ void daq::streaming_protocol::siggen::addSignals(daq::streaming_protocol::siggen
     dblSignalParameters.frequency = 0.2;
     dblSignalParameters.functionType = daq::streaming_protocol::siggen::FUNCTION_TYPE_SAWTOOTH;
     signalGenerator.addLinearTimeSignal("saw_tooth_time", "table_100ms", samplePeriod);
-    signalGenerator.addSynchronousSignal<double>("saw_tooth", "table_100ms", dblSignalParameters, samplePeriod, 0);
+    signalGenerator.addSynchronousSignal<double>("saw_tooth", "table_100ms", "saw_tooth_time", dblSignalParameters, samplePeriod, 0);
     // ToDo: This should work for test purposes - but the handling of the value index is not in sync to the correct time.
-    signalGenerator.addSynchronousSignal<double>("saw_tooth_2", "table_100ms", dblSignalParameters, samplePeriod, 100);
+    signalGenerator.addSynchronousSignal<double>("saw_tooth_2", "table_100ms", "saw_tooth_time",dblSignalParameters, samplePeriod, 100);
 
     dblSignalParameters.amplitude = 2.5;
     dblSignalParameters.offset = 0;
     dblSignalParameters.frequency = 0.5;
     dblSignalParameters.dutyCycle = 0.0;
     dblSignalParameters.functionType = FUNCTION_TYPE_IMPULSE;
-    signalGenerator.addSynchronousSignal("impulse", "table_100ms", dblSignalParameters, samplePeriod, 0);
+    signalGenerator.addSynchronousSignal("impulse", "table_100ms", "saw_tooth_time", dblSignalParameters, samplePeriod, 0);
 
     // we want whole numbers here!
     samplePeriod = std::chrono::seconds(1);
@@ -88,6 +88,5 @@ void daq::streaming_protocol::siggen::addSignals(daq::streaming_protocol::siggen
     int32SignalParameters.dutyCycle = 0.0;
     int32SignalParameters.functionType = FUNCTION_TYPE_SAWTOOTH;
     signalGenerator.addLinearTimeSignal("slow_counter_time", "table_1s", samplePeriod);
-    signalGenerator.addSynchronousSignal<int32_t>("slow_counter", "table_1s", int32SignalParameters, samplePeriod, 0);
-
+    signalGenerator.addSynchronousSignal<int32_t>("slow_counter", "table_1s", "slow_counter_time", int32SignalParameters, samplePeriod, 0);
 }


### PR DESCRIPTION
This does supersede https://github.com/openDAQ/streaming-protocol-lt/pull/53.

Related signals can be set on the producer side
Related signals can be accessed on the consumer side.

Includes a fix of the specification!