### PR TITLE
Fix race vondition on access to m_stream

### DIFF
--- a/include/streaming_protocol/ProtocolHandler.hpp
+++ b/include/streaming_protocol/ProtocolHandler.hpp
@@ -85,6 +85,9 @@ namespace daq::streaming_protocol {
         SignalContainer& m_signalContainer;
         StreamMetaCb m_streamMetaCb;
         std::unique_ptr < daq::stream::Stream > m_stream;
+        /// Will be set upon start with infomation from m_stream.
+        /// We use this to omit possible race condition after reset of m_stream
+        std::string m_remoteHost;
         CompletionCb m_completionCb;
         boost::system::error_code m_sessionEc;
 


### PR DESCRIPTION
Instead of calling a method that might not be available anymore to just get the remote host name, we simply keep this information in a string when starting.

 