### PR TITLE
v1.2.2 address reported issues:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT CMAKE_MESSAGE_CONTEXT)
     set(CMAKE_MESSAGE_CONTEXT_SHOW ON CACHE BOOL "Show CMake message context")
 endif()
 
-project(streaming_protocol_complete VERSION 1.2.1 LANGUAGES CXX)
+project(streaming_protocol_complete VERSION 1.2.2 LANGUAGES CXX)
 
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)

--- a/include/streaming_protocol/BaseConstantSignal.hpp
+++ b/include/streaming_protocol/BaseConstantSignal.hpp
@@ -24,7 +24,7 @@ namespace daq::streaming_protocol{
 /// Abstrace base class for producing constant rule signal data
 class BaseConstantSignal : public BaseValueSignal {
 public:
-    BaseConstantSignal(const std::string& signalId, const std::string& tableId, iWriter &writer, LogCallback logCb);
+    BaseConstantSignal(const std::string& signalId, const std::string& tableId, iWriter& writer, const nlohmann::json& defaultStartValue, LogCallback logCb);
 
     virtual int addData(const void* values, const uint64_t* indices, size_t valuesCount) = 0;
 
@@ -35,6 +35,8 @@ protected:
 
     nlohmann::json createMember(const std::string& dataType) const;
     virtual nlohmann::json getMemberInformation() const = 0;
+
+    nlohmann::json m_defaultStartValue;
 };
 
 }

--- a/include/streaming_protocol/ConstantSignal.hpp
+++ b/include/streaming_protocol/ConstantSignal.hpp
@@ -34,8 +34,8 @@ template < class DataType >
 class ConstantSignal : public BaseConstantSignal {
 public:
     /// \param signalId The signal id. Unique on this streaming server.
-    ConstantSignal(const std::string& signalId, const std::string& tableId, iWriter& writer, LogCallback logCb)
-        : BaseConstantSignal(signalId, tableId, writer, logCb)
+    ConstantSignal(const std::string& signalId, const std::string& tableId, iWriter& writer, const nlohmann::json& defaultStartValue, LogCallback logCb)
+        : BaseConstantSignal(signalId, tableId, writer, defaultStartValue, logCb)
     {
     }
 

--- a/include/streaming_protocol/ControlServer.hpp
+++ b/include/streaming_protocol/ControlServer.hpp
@@ -57,7 +57,8 @@ public:
 
 private:
     boost::asio::io_context& m_ioc;
-    std::shared_ptr<listener> m_listener;
+    std::shared_ptr<listener> m_listener_v4;
+    std::shared_ptr<listener> m_listener_v6;
     uint16_t m_port;
     CommandCb m_commandCb;
     LogCallback logCallback;

--- a/include/streaming_protocol/Defines.h
+++ b/include/streaming_protocol/Defines.h
@@ -129,6 +129,6 @@ static const char META_RANGE[] = "range";
 static const char META_LOW[] = "low";
 static const char META_HIGH[] = "high";
 
-static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.0";
+static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.2";
 
 }

--- a/include/streaming_protocol/SubscribedSignal.hpp
+++ b/include/streaming_protocol/SubscribedSignal.hpp
@@ -118,7 +118,9 @@ public:
     /// >0 if signal has a linear time rule. If 0 the signal does not have a linear time rule!
     uint64_t timeLinearDelta() const
     {
-        return m_linearDelta;
+        if (m_timeSignal)
+            return m_timeSignal->m_linearDelta;
+        return 0;
     }
 
     /// \return The unit or an empty string when there is no unit
@@ -162,6 +164,11 @@ public:
         return m_linearDelta;
     }
 
+    nlohmann::json linearDeltaMeta() const
+    {
+        return m_linearDeltaJson;
+    }
+
     std::string timeBaseEpochAsString() const
     {
         return m_timeBaseEpochAsString;
@@ -195,6 +202,11 @@ public:
     Range range() const
     {
         return m_range;
+    }
+
+    nlohmann::json constRuleStartMeta() const
+    {
+        return m_constRuleStartJson;
     }
 
 private:
@@ -241,6 +253,8 @@ private:
     std::shared_ptr<SubscribedSignal> m_timeSignal;
     uint64_t m_time;
     uint64_t m_linearDelta;
+    nlohmann::json m_linearDeltaJson;
+    nlohmann::json m_constRuleStartJson;
     size_t m_linearValueIndex;
     std::string m_timeBaseEpochAsString;
     uint64_t m_timeBaseFrequency;

--- a/lib/BaseConstantSignal.cpp
+++ b/lib/BaseConstantSignal.cpp
@@ -3,8 +3,9 @@
 
 BEGIN_NAMESPACE_STREAMING_PROTOCOL
 
-BaseConstantSignal::BaseConstantSignal(const std::string &signalId, const std::string &tableId, iWriter &writer, LogCallback logCb)
+BaseConstantSignal::BaseConstantSignal(const std::string& signalId, const std::string& tableId, iWriter& writer, const nlohmann::json& defaultStartValue, LogCallback logCb)
     : BaseValueSignal(signalId, tableId, writer, logCb)
+    , m_defaultStartValue(defaultStartValue)
 {
 }
 
@@ -20,12 +21,15 @@ void BaseConstantSignal::writeSignalMetaInformation() const
     m_writer.writeMetaInformation(m_signalNumber, dataSignal);
 }
 
-nlohmann::json BaseConstantSignal::createMember(const std::string &dataType) const
+nlohmann::json BaseConstantSignal::createMember(const std::string& dataType) const
 {
     nlohmann::json memberInformation;
     memberInformation[META_NAME] = m_valueName;
     memberInformation[META_DATATYPE] = dataType;
     memberInformation[META_RULE] = META_RULETYPE_CONSTANT;
+    if (!m_defaultStartValue.is_null()) {
+        memberInformation[META_RULETYPE_CONSTANT][META_START] = m_defaultStartValue;
+    }
     if (m_unitId != Unit::UNIT_ID_NONE) {
         memberInformation[META_UNIT][META_UNIT_ID] = m_unitId;
         memberInformation[META_UNIT][META_DISPLAY_NAME] = m_unitDisplayName;

--- a/lib/ControlServer.cpp
+++ b/lib/ControlServer.cpp
@@ -18,6 +18,7 @@
 #include <boost/beast/http/string_body.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/asio/strand.hpp>
+#include <boost/asio/ip/v6_only.hpp>
 #include <boost/config.hpp>
 #include <algorithm>
 #include <functional>
@@ -136,7 +137,7 @@ void handle_request(http::request<Body, http::basic_fields<Allocator>>&& req,
     return send(std::move(res));
 }
 
-static void fail(beast::error_code ec, char const* what, LogCallback logCallback)
+static void log_error(beast::error_code ec, char const* what, LogCallback logCallback)
 {
     STREAMING_PROTOCOL_LOG_E("{}: {}", what, ec.message());
 }
@@ -229,7 +230,7 @@ public:
         }
 
         if(ec) {
-            fail(ec, "read", logCallback);
+            log_error(ec, "read", logCallback);
             return;
         }
 
@@ -242,7 +243,7 @@ public:
         boost::ignore_unused(bytes_transferred);
 
         if(ec) {
-            fail(ec, "write", logCallback);
+            log_error(ec, "write", logCallback);
             return;
         }
 
@@ -292,35 +293,30 @@ public:
         // Open the acceptor
         m_acceptor.open(endpoint.protocol(), ec);
         if(ec)
+            throw std::runtime_error(::fmt::format("open: {}", ec.message()));
+
+        if (endpoint.address().is_v6())
         {
-            fail(ec, "open", logCallback);
-            return;
+            m_acceptor.set_option(net::ip::v6_only(true), ec);
+            if(ec)
+                throw std::runtime_error(::fmt::format("set_option v6 only: {}", ec.message()));
         }
 
         // Allow address reuse
-        m_acceptor.set_option(net::socket_base::reuse_address(true), ec);
+        m_acceptor.set_option(tcp::acceptor::reuse_address(true), ec);
         if(ec)
-        {
-            fail(ec, "set_option", logCallback);
-            return;
-        }
+            throw std::runtime_error(::fmt::format("set_option reuse: {}", ec.message()));
 
         // Bind to the server address
         m_acceptor.bind(endpoint, ec);
         if(ec)
-        {
-            fail(ec, "bind", logCallback);
-            return;
-        }
+            throw std::runtime_error(::fmt::format("bind: {}", ec.message()));
 
         // Start listening for connections
         m_acceptor.listen(
             net::socket_base::max_listen_connections, ec);
         if(ec)
-        {
-            fail(ec, "listen", logCallback);
-            return;
-        }
+            throw std::runtime_error(::fmt::format("listen: {}", ec.message()));
     }
 
     // Start accepting incoming connections
@@ -338,7 +334,7 @@ public:
         m_acceptor.close(ec);
         if(ec)
         {
-            fail(ec, "close", logCallback);
+            log_error(ec, "close", logCallback);
         }
     }
 
@@ -356,7 +352,7 @@ private:
     void on_accept(beast::error_code ec, tcp::socket socket)
     {
         if(ec) {
-            fail(ec, "accept", logCallback);
+            log_error(ec, "accept", logCallback);
         } else {
             // Create the session and run it
             std::make_shared<session>(std::move(socket), m_commandCb, logCallback)->run();
@@ -385,18 +381,32 @@ ControlServer::~ControlServer()
 
 void ControlServer::start()
 {
-    // listen to any interface using ipv4 or ipv6
-    auto const address = net::ip::make_address("::");
+    try {
+        // listen to any interface using ipv4
+        m_listener_v4 = std::make_shared<listener>(m_ioc, tcp::endpoint{net::ip::tcp::v4(), m_port}, m_commandCb, logCallback);
+        m_listener_v4->run();
+    }
+    catch (const std::exception& e) {
+        STREAMING_PROTOCOL_LOG_W("Failed to start listen on v4 addresses: {}", e.what());
+    }
 
-    // Create and launch a listening port
-    m_listener = std::make_shared<listener>(m_ioc, tcp::endpoint{address, m_port}, m_commandCb, logCallback);
-    m_listener->run();
+    try {
+        // listen to any interface using ipv6
+        m_listener_v6 = std::make_shared<listener>(m_ioc, tcp::endpoint{net::ip::tcp::v6(), m_port}, m_commandCb, logCallback);
+        m_listener_v6->run();
+    }
+    catch (const std::exception& e) {
+        STREAMING_PROTOCOL_LOG_W("Failed to start listen on v6 addresses: {}", e.what());
+    }
 }
 
 void ControlServer::stop()
 {
-    if (m_listener)
-        m_listener->stop();
+    if (m_listener_v4)
+        m_listener_v4->stop();
+
+    if (m_listener_v6)
+        m_listener_v6->stop();
 }
 
 uint16_t ControlServer::getPort()

--- a/lib/ProtocolHandler.cpp
+++ b/lib/ProtocolHandler.cpp
@@ -136,9 +136,7 @@ namespace daq::streaming_protocol {
         switch(m_type) {
         case TYPE_SIGNALDATA:
             if (m_signalContainer.processMeasuredData(m_signalNumber, m_stream->data(), m_length) < 0) {
-                boost::system::error_code localEc = boost::system::errc::make_error_code(boost::system::errc::protocol_error);
-                closeSession(localEc, "failed to interprete measured data!");
-                return;
+                STREAMING_PROTOCOL_LOG_E("Failed to interprete measured data!");
             }
             break;
         case TYPE_METAINFORMATION:

--- a/lib/ProtocolHandler.cpp
+++ b/lib/ProtocolHandler.cpp
@@ -45,15 +45,18 @@ namespace daq::streaming_protocol {
 
     void ProtocolHandler::subscribe(const SignalIds& signalIds)
     {
-        try {
-            Controller controller(m_ioc, m_streamMeta.streamId(), m_stream->remoteHost(), m_streamMeta.httpControlPort(), m_streamMeta.httpControlPath(), m_streamMeta.httpVersion(), logCallback);
-            controller.asyncSubscribe(signalIds, [this](const boost::system::error_code& ec) {
-                if (ec) {
-                    STREAMING_PROTOCOL_LOG_E("Control request failed: {}", ec.message());
-                }
-            });
-        }  catch (const std::runtime_error& e) {
-            STREAMING_PROTOCOL_LOG_E("{} {}: Won't subscribe!", m_stream->endPointUrl(), e.what());
+        if (m_stream)
+        {
+            try {
+                Controller controller(m_ioc, m_streamMeta.streamId(), m_stream->remoteHost(), m_streamMeta.httpControlPort(), m_streamMeta.httpControlPath(), m_streamMeta.httpVersion(), logCallback);
+                controller.asyncSubscribe(signalIds, [this](const boost::system::error_code& ec) {
+                    if (ec) {
+                        STREAMING_PROTOCOL_LOG_E("Control request failed: {}", ec.message());
+                    }
+                });
+            }  catch (const std::runtime_error& e) {
+                STREAMING_PROTOCOL_LOG_E("{} {}: Won't subscribe!", m_stream->endPointUrl(), e.what());
+            }
         }
     }
     

--- a/lib/SignalContainer.cpp
+++ b/lib/SignalContainer.cpp
@@ -139,7 +139,7 @@ ssize_t SignalContainer::processMeasuredData(SignalNumber signalNumber, const un
 {
     Signals::iterator signalIter = m_subscribedSignals.find(signalNumber);
     if (signalIter == m_subscribedSignals.end()) {
-        STREAMING_PROTOCOL_LOG_E("Got data for signal '{}', that was not subscribed before", signalNumber);
+        STREAMING_PROTOCOL_LOG_W("Got data for signal '{}', that has not been yet reported as subscribed by server", signalNumber);
         return -1;
     }
 
@@ -184,7 +184,7 @@ ssize_t SignalContainer::processMeasuredData(SignalNumber signalNumber, const un
             const Table& table = tableIter->second;
             unsigned int timeSignalNumber = table.timeSignalNumber;
             if (timeSignalNumber == 0) {
-                STREAMING_PROTOCOL_LOG_E("No time signal available for signal id '{}', number {}, table '{}'!",
+                STREAMING_PROTOCOL_LOG_W("The time signal isn't yet known for value signal id '{}', number {}, table '{}'!",
                                          signalIter->second->signalId(),
                                          signalNumber,
                                          tableId);


### PR DESCRIPTION
* keep client session open when unknown or incomplete signal's data received
* provide raw json value for linear rule delta of subscribed signal
* encode and decode start value for constant rule signal within json meta-data
* properly accept control connections via IPv4/v6

related PR https://github.com/openDAQ/openDAQ/pull/696