### PR TITLE
Adjustments to support struct / CAN streaming and explicit-rule domain signals

### DIFF
--- a/include/streaming_protocol/Defines.h
+++ b/include/streaming_protocol/Defines.h
@@ -129,6 +129,9 @@ static const char META_RANGE[] = "range";
 static const char META_LOW[] = "low";
 static const char META_HIGH[] = "high";
 
+static const char META_DIMENSIONS[] = "dimensions";
+static const char META_SIZE[] = "size";
+
 static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.3";
 
 }

--- a/include/streaming_protocol/SubscribedSignal.hpp
+++ b/include/streaming_protocol/SubscribedSignal.hpp
@@ -219,6 +219,11 @@ public:
         return m_constRuleStartJson;
     }
 
+    const nlohmann::json& datatypeDetails() const
+    {
+        return m_datatypeDetails;
+    }
+
 private:
 
     template < typename DataType >

--- a/lib/SignalContainer.cpp
+++ b/lib/SignalContainer.cpp
@@ -160,6 +160,7 @@ ssize_t SignalContainer::processMeasuredData(SignalNumber signalNumber, const un
                     STREAMING_PROTOCOL_LOG_D("{}:\n\tTime is: {}", dataSignal->signalId(), timeStamp);
                 }
             }
+            signal->processMeasuredData(data, len, nullptr, m_dataAsRawCb, m_dataAsValueCb);
         } else {
             // for implicit time rule:
             // 1st 64 bit are value index, followed by 64 bit timestamp

--- a/lib/SubscribedSignal.cpp
+++ b/lib/SubscribedSignal.cpp
@@ -417,7 +417,7 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                         return -1;
                     }
                     // numerator/denominator gives time between ticks, or period, in the uint of the signal.
-                    if (m_unit.unitId == Unit::UNIT_ID_SECONDS || (m_unit.unitId == -1 && m_unit.displayName == "s")) {
+                    if (m_unit.unitId == Unit::UNIT_ID_SECONDS || (m_unit.unitId == Unit::UNIT_ID_NONE && m_unit.displayName == "s")) {
                         // Unit for time signals is seconds. We want the frequency here!
                         m_timeBaseFrequency = denominator / numerator;
                         STREAMING_PROTOCOL_LOG_I("\ttime resolution: {} Hz", resolutionNode.dump());

--- a/lib/SubscribedSignal.cpp
+++ b/lib/SubscribedSignal.cpp
@@ -73,15 +73,17 @@ ssize_t SubscribedSignal::processMeasuredData(const unsigned char* pData, size_t
         // In openDAQ streaming protocol, time stamp and value are delivered separately as explicit values
         // in the time signal and the data signal.
         // The device will deliver the time stamp before the value => Time (m_time) is already set! 
-        // This of course works only when there is one asynchronous value at a time.
-        // As a result, only one value can be processed here!
-        if (size != m_dataValueSize) {
-            STREAMING_PROTOCOL_LOG_E("Only one asynchronous signal value can be handled here");
+        if ((size % m_dataValueSize) != 0) {
+            STREAMING_PROTOCOL_LOG_E("Data is not an even multiple of expected data size");
             return (ssize_t) size;
         }
 
-        cbRaw(*this, timeSignal->m_time, pData, m_dataValueSize);
-        cbValues(*this, timeSignal->m_time, pData, 1);
+        std::size_t offset = 0;
+        while (offset + m_dataValueSize <= size) {
+            cbRaw(*this, timeSignal->m_time, pData + offset, m_dataValueSize);
+            cbValues(*this, timeSignal->m_time, pData + offset, 1);
+            offset += m_dataValueSize;
+        }
         break;
     }
     case RULETYPE_CONSTANT:
@@ -98,46 +100,72 @@ ssize_t SubscribedSignal::processMeasuredData(const unsigned char* pData, size_t
 
 static size_t getDataTypeSize(const nlohmann::json& definitionNode)
 {
+    std::size_t count = 1;
+    std::string name = definitionNode.value(META_NAME, "");
+
+    // Check for one-dimensional arrays of primitives.
+    if (definitionNode.count(META_DIMENSIONS) > 0)
+    {
+        auto dimensions = definitionNode[META_DIMENSIONS];
+        if (!dimensions.is_array() ||
+                dimensions.size() != 1 ||
+                !dimensions[0].is_object())
+            return 0;
+
+        auto dimension = dimensions[0];
+        if (dimension.value(META_RULE, "") != "linear" ||
+                dimension.count(META_RULETYPE_LINEAR) != 1 ||
+                !dimension[META_RULETYPE_LINEAR].is_object())
+            return 0;
+
+        auto linear = dimension[META_RULETYPE_LINEAR];
+        if (linear.value(META_START, 0) != 1 ||
+                linear.value(META_DELTA, 0) != 0)
+            return 0;
+
+        count = linear.value(META_SIZE, 1);
+    }
+
     auto dataTypeIter = definitionNode.find(META_DATATYPE);
     if (dataTypeIter != definitionNode.end()) {
         nlohmann::json datatypeNode = *dataTypeIter;
         std::string dataType = datatypeNode;
         if (dataType == DATA_TYPE_UINT8) {
-            return sizeof(uint8_t);
+            return sizeof(uint8_t) * count;
         } else if (dataType == DATA_TYPE_UINT16) {
-            return sizeof(uint16_t);
+            return sizeof(uint16_t) * count;
         } else if (dataType == DATA_TYPE_UINT32) {
-            return sizeof(uint32_t);
+            return sizeof(uint32_t) * count;
         } else if (dataType == DATA_TYPE_UINT64) {
-            return sizeof(uint64_t);;
+            return sizeof(uint64_t) * count;
         } else if (dataType == DATA_TYPE_INT8) {
-            return sizeof(int8_t);;
+            return sizeof(int8_t) * count;
         } else if (dataType == DATA_TYPE_INT16) {
-            return sizeof(int16_t);;
+            return sizeof(int16_t) * count;
         } else if (dataType == DATA_TYPE_INT32) {
-            return sizeof(int32_t);;
+            return sizeof(int32_t) * count;
         } else if (dataType == DATA_TYPE_INT64) {
-            return sizeof(int64_t);;
+            return sizeof(int64_t) * count;
         } else if (dataType == DATA_TYPE_REAL32) {
-            return sizeof(float);;
+            return sizeof(float) * count;
         } else if (dataType == DATA_TYPE_REAL64) {
-            return sizeof(double);;
+            return sizeof(double) * count;
         } else if (dataType == DATA_TYPE_COMPLEX32) {
-            return sizeof(Complex32Type);
+            return sizeof(Complex32Type) * count;
         } else if (dataType == DATA_TYPE_COMPLEX64) {
-            return sizeof(Complex64Type);
+            return sizeof(Complex64Type) * count;
         } else if (dataType == DATA_TYPE_BITFIELD) {
             nlohmann::json subDatatypeNode = definitionNode[DATA_TYPE_BITFIELD];
-            return getDataTypeSize(subDatatypeNode);
+            return getDataTypeSize(subDatatypeNode) * count;
         } else if (dataType == DATA_TYPE_ARRAY) {
             nlohmann::json subDatatypeNode = definitionNode[DATA_TYPE_ARRAY];
-            size_t count = subDatatypeNode[META_COUNT];
-            return getDataTypeSize(subDatatypeNode) * count;
+            size_t arrayCount = subDatatypeNode[META_COUNT];
+            return getDataTypeSize(subDatatypeNode) * count * arrayCount;
         } else if (dataType == DATA_TYPE_STRUCT) {
             size_t dataTypeSize = 0;
             for (const auto& subDatatypeNodeIter: definitionNode[DATA_TYPE_STRUCT] ) {
                 const nlohmann::json& subDatatypeNode = subDatatypeNodeIter;
-                dataTypeSize += getDataTypeSize(subDatatypeNode);
+                dataTypeSize += getDataTypeSize(subDatatypeNode) * count;
             }
             return dataTypeSize;
         } else {
@@ -389,7 +417,7 @@ int SubscribedSignal::processSignalMetaInformation(const std::string& method, co
                         return -1;
                     }
                     // numerator/denominator gives time between ticks, or period, in the uint of the signal.
-                    if (m_unit.unitId == Unit::UNIT_ID_SECONDS) {
+                    if (m_unit.unitId == Unit::UNIT_ID_SECONDS || (m_unit.unitId == -1 && m_unit.displayName == "s")) {
                         // Unit for time signals is seconds. We want the frequency here!
                         m_timeBaseFrequency = denominator / numerator;
                         STREAMING_PROTOCOL_LOG_I("\ttime resolution: {} Hz", resolutionNode.dump());


### PR DESCRIPTION
This PR includes some relatively minor changes. These changes enable streaming of simple structures, including CAN channels. They also enable streaming signals with explicit-rule domain signals.

The following things were changed:

- `getDataTypeSize()` now recognizes one-dimensional arrays of primitives and calculates the size correctly. This is required for the data member of the CAN packet structure.
- `SubscribedSignal` now has an accessor `datatypeDetails()` which, for signals with structure value types, returns the `definition.struct` JSON node. This will be used in the openDAQ SDK to examine the structure and regenerate the openDAQ data descriptor for it.
- `SignalContainer::processMeasuredData()` now calls `SubscribedSignal::processMeasuredData()` for packets on domain signals. The latter has been adapted to be able to handle this. Previously domain signal packets were not processed beyond this point, but this is required for explicit-rule domain signals.

These changes have already been consumed and tested in a branch of the openDAQ SDK. An SDK PR will follow, once this is merged.