### PR TITLE
fix building the project on clang 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT CMAKE_MESSAGE_CONTEXT)
     set(CMAKE_MESSAGE_CONTEXT_SHOW ON CACHE BOOL "Show CMake message context")
 endif()
 
-project(streaming_protocol_complete VERSION 1.2.5 LANGUAGES CXX)
+project(streaming_protocol_complete VERSION 1.2.6 LANGUAGES CXX)
 
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)

--- a/docs/openDAQ-signal-definition-examples.md
+++ b/docs/openDAQ-signal-definition-examples.md
@@ -2,7 +2,7 @@
 title:  openDAQ Signal Definition Examples
 author: Matthias Loy, Helge Rasmussen
 version: 0.1
-subtitle: Version 1.2.5
+subtitle: Version 1.2.6
 titlepage: true
 toc: true
 toc-own-page: true

--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -1,6 +1,6 @@
 ---
 title:  openDAQ Stream Protocol Specification
-subtitle: Version 1.2.5
+subtitle: Version 1.2.6
 titlepage: true
 toc: true
 toc-own-page: true

--- a/include/streaming_protocol/Defines.h
+++ b/include/streaming_protocol/Defines.h
@@ -132,6 +132,6 @@ static const char META_HIGH[] = "high";
 static const char META_DIMENSIONS[] = "dimensions";
 static const char META_SIZE[] = "size";
 
-static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.5";
+static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.6";
 
 }

--- a/lib/MetaInformation.cpp
+++ b/lib/MetaInformation.cpp
@@ -23,7 +23,8 @@ namespace daq::streaming_protocol {
         case METAINFORMATION_MSGPACK:
             {
                 try {
-                    m_jsonContent = nlohmann::json::from_msgpack(data+sizeof(m_metaInformationType), data+size);
+                    m_jsonContent = nlohmann::json::from_msgpack(reinterpret_cast<const char*>(data+sizeof(m_metaInformationType)), 
+                                                                 reinterpret_cast<const char*>(data+size));
                 } catch (const nlohmann::json::parse_error& e) {
                     STREAMING_PROTOCOL_LOG_E("parsing meta information failed : {}", e.what());
                     return -1;

--- a/tool/SignalGenerator/CMakeLists.txt
+++ b/tool/SignalGenerator/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project("Signal Generator" VERSION 1.2.5)
+project("Signal Generator" VERSION 1.2.6)
 
 # Adding nanoseconds to a point in time does work on Linux only
 # Other platforms convert nanoseconds to microseconds and loose some accuracy


### PR DESCRIPTION
the nlohmann::json has deprecated using the uint8_t for clang started from version 18