### PR TITLE
JSON library update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 cmake_minimum_required(VERSION 3.24)
 
 if (NOT CMAKE_MESSAGE_CONTEXT)
@@ -5,7 +6,7 @@ if (NOT CMAKE_MESSAGE_CONTEXT)
     set(CMAKE_MESSAGE_CONTEXT_SHOW ON CACHE BOOL "Show CMake message context")
 endif()
 
-project(streaming_protocol_complete VERSION 1.2.6 LANGUAGES CXX)
+project(streaming_protocol_complete VERSION 1.2.7 LANGUAGES CXX)
 
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)

--- a/docs/openDAQ-signal-definition-examples.md
+++ b/docs/openDAQ-signal-definition-examples.md
@@ -2,7 +2,7 @@
 title:  openDAQ Signal Definition Examples
 author: Matthias Loy, Helge Rasmussen
 version: 0.1
-subtitle: Version 1.2.6
+subtitle: Version 1.2.7
 titlepage: true
 toc: true
 toc-own-page: true

--- a/docs/openDAQ-streaming.md
+++ b/docs/openDAQ-streaming.md
@@ -1,6 +1,6 @@
 ---
 title:  openDAQ Stream Protocol Specification
-subtitle: Version 1.2.6
+subtitle: Version 1.2.7
 titlepage: true
 toc: true
 toc-own-page: true

--- a/include/streaming_protocol/Defines.h
+++ b/include/streaming_protocol/Defines.h
@@ -132,6 +132,6 @@ static const char META_HIGH[] = "high";
 static const char META_DIMENSIONS[] = "dimensions";
 static const char META_SIZE[] = "size";
 
-static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.6";
+static const char OPENDAQ_LT_STREAM_VERSION[] = "1.2.7";
 
 }

--- a/lib/external/nlohman_json/CMakeLists.txt
+++ b/lib/external/nlohman_json/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.24)
 
 set_cmake_folder_context(TARGET_FOLDER_NAME)
 
-set(nlohmann_json_REQUIREDVERSION "3.10.5")
+set(nlohmann_json_REQUIREDVERSION "3.11.3")
 if (NOT STREAMING_PROTOCOL_ALWAYS_FETCH_DEPS)
     message(STATUS "Looking for preinstalled nlohmann_json")
     find_package(nlohmann_json GLOBAL QUIET ${nlohmann_json_REQUIREDVERSION})

--- a/tool/SignalGenerator/CMakeLists.txt
+++ b/tool/SignalGenerator/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project("Signal Generator" VERSION 1.2.6)
+project("Signal Generator" VERSION 1.2.7)
 
 # Adding nanoseconds to a point in time does work on Linux only
 # Other platforms convert nanoseconds to microseconds and loose some accuracy


### PR DESCRIPTION
- **nlohmann-json** required version changed from **3.10.5** -> **3.11.3**
- **CMAKE_POLICY_VERSION_MINIMUM** set to work with **cmake >= 4.0**